### PR TITLE
Fix: Add image tag to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   streamer:
+    image: streamer:latest
     build: .
     env_file:
       - .env


### PR DESCRIPTION
The Docker image was not being tagged when built locally using docker-compose.

This change adds the `image: streamer:latest` instruction to the `streamer` service in the `docker-compose.yml` file. This ensures the image is tagged correctly after a successful build.